### PR TITLE
ci(s
chema): add dataset schema + CI validation with AJV fallback

### DIFF
--- a/.github/workflows/validate-datasets.yml
+++ b/.github/workflows/validate-datasets.yml
@@ -1,0 +1,80 @@
+name: Validate Datasets
+
+on:
+  pull_request:
+    paths:
+      - 'datasets/**.json'
+      - 'schemas/dataset.schema.json'
+      - '.github/workflows/validate-datasets.yml'
+  push:
+    branches: [ main ]
+    paths:
+      - 'datasets/**.json'
+      - 'schemas/dataset.schema.json'
+  workflow_dispatch: {}
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Detect dataset files
+        id: detect
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          files=(datasets/*.json)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "found=0" >> "$GITHUB_OUTPUT"
+          else
+            printf '%s\n' "${files[@]}" > dataset-files.txt
+            echo "found=1" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Validate with AJV (JSON Schema)
+        if: steps.detect.outputs.found == '1'
+        run: |
+          set -e
+          # Try AJV via npx; if the tool/network fails, mark a special status and continue
+          if npx --yes ajv-cli@5.0.0 validate -s schemas/dataset.schema.json -d 'datasets/*.json' --spec=draft2020; then
+            echo "AJV validation passed"
+          else
+            echo "AJV validation failed or unavailable; will attempt Python fallback"
+            echo "AJV_FAILED=1" >> $GITHUB_ENV
+          fi
+
+      - name: Fallback validation with python jsonschema
+        if: steps.detect.outputs.found == '1' && env.AJV_FAILED == '1'
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip jsonschema
+          python - <<'PY'
+          import json, sys, glob
+          from jsonschema import Draft202012Validator
+
+          with open('schemas/dataset.schema.json', 'r', encoding='utf-8') as f:
+              schema = json.load(f)
+          validator = Draft202012Validator(schema)
+          failed = False
+          for path in glob.glob('datasets/*.json'):
+              with open(path, 'r', encoding='utf-8') as f:
+                  data = json.load(f)
+              errs = sorted(validator.iter_errors(data), key=lambda e: e.path)
+              if errs:
+                  failed = True
+                  print(f"❌ Validation errors in {path}:")
+                  for e in errs:
+                      loc = "/".join([str(x) for x in e.path])
+                      print(f" - {loc or '<root>'}: {e.message}")
+          if failed:
+              sys.exit(1)
+          else:
+              print('✅ All datasets valid')
+          PY
+
+      - name: No datasets found
+        if: steps.detect.outputs.found != '1'
+        run: echo "No dataset files found; skipping validation."
+

--- a/datasets/README.md
+++ b/datasets/README.md
@@ -1,0 +1,23 @@
+Datasets
+========
+
+Add dataset JSON files in this directory to be validated in CI.
+
+Schema
+- Schema lives at `schemas/dataset.schema.json` (Draft 2020-12)
+- Minimal example:
+
+```
+{
+  "name": "example",
+  "description": "Sample dataset for CI validation",
+  "items": [
+    {"id": "1", "input": "hello", "expected": "world", "tags": ["smoke"]}
+  ]
+}
+```
+
+CI Validation
+- On PRs touching `datasets/*.json`, CI validates with `ajv-cli` and falls back to Python `jsonschema` if needed.
+- Validation errors point to the offending field for quick fixes.
+

--- a/schemas/dataset.schema.json
+++ b/schemas/dataset.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schemas/dataset.schema.json",
+  "title": "DriftGuard Dataset",
+  "description": "Schema for test/evaluation datasets consumed by DriftGuard checks.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["name", "items"],
+  "properties": {
+    "name": {"type": "string", "minLength": 1},
+    "description": {"type": "string"},
+    "version": {"type": "string"},
+    "created_at": {"type": "string", "format": "date-time"},
+    "metadata": {"type": "object"},
+    "threshold": {"type": "number", "minimum": 0, "maximum": 1},
+    "items": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["input", "expected"],
+        "properties": {
+          "id": {"type": "string"},
+          "input": {"type": "string", "minLength": 1},
+          "expected": {"type": "string"},
+          "tags": {
+            "type": "array",
+            "items": {"type": "string"}
+          },
+          "meta": {"type": "object"}
+        }
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
Adds Draft
 2020-12 schema at schemas/dataset.schema.json and CI validation workflow. Uses
ajv-cli via npx with Python jsonschema fallback. Skips when no datasets present.
 Risk: low, additive.